### PR TITLE
Full UTF8 support and simpler error handling

### DIFF
--- a/internal/examples/reader/main.go
+++ b/internal/examples/reader/main.go
@@ -18,6 +18,7 @@ func main() {
 	cr, err := csv.NewReader(
 		op.Reader(r),
 		op.Quote('"'),
+		op.ErrorOnQuotesInUnquotedField(false),
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Also since the RFC spec technically demands all quotes in a field to be double quoted, its now going to be treated as an error by default.

The `ErrorOnQuotesInUnquotedField(false)` option can be used to disable this and perform the previous best-effort default parsing approach. Note if you find yourself using this option your writers upstream need some love and attention (changes).