### PR TITLE
Add IntoIter() method for go1.23 and support for escape characters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/josephcopenhaver/csv-go
 
-go 1.22.0
+go 1.23

--- a/internal/examples/reader/main.go
+++ b/internal/examples/reader/main.go
@@ -24,8 +24,7 @@ func main() {
 		panic(err)
 	}
 
-	for cr.Scan() {
-		row := cr.Row()
+	for row := range cr.IntoIter() {
 		println(strings.Join(row, ","))
 	}
 	if err := cr.Err(); err != nil {


### PR DESCRIPTION
I'm not sure it is kosher to do this (export a Rows() method which creates an iterator instance) given the iterator state cannot ever be reset and is an internal detail not owned by the iterator context. It probably is not a good idea, gonna mull it over.