### PR TITLE
example should defer close of the reader

### DIFF
--- a/internal/examples/reader/main.go
+++ b/internal/examples/reader/main.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	defer cr.Close()
 
 	for row := range cr.IntoIter() {
 		println(strings.Join(row, ","))


### PR DESCRIPTION
Showcasing the defer of Close in example.