### PR TITLE
bugfix: single column but record starts with rec-sep

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 ![code-coverage](https://img.shields.io/badge/code_coverage-100%25-rgb%2852%2C208%2C88%29)
 
 ## Why does this exist?
-I am tired of rewriting this over and over to cover edge cases where other language standard csv implementations have assertions on the format and formatting I can cannot guarantee are valid. I've written variations that cover far less concerns over the years and figured I'll make a superset of one that does everything I need. Feel free to use however you may wish.
+I am tired of rewriting this over and over to cover edge cases where other language standard csv implementations have assertions on the format and formatting I cannot guarantee are valid for a given file and how it was constructed. I've written variations that cover far fewer concerns over the years, and I figured I'll make a superset of one that does everything I need. Feel free to use however you may wish.

--- a/functional_reader_prepare_row_error_test.go
+++ b/functional_reader_prepare_row_error_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 const (
-	utf8LineSeparatorRune rune = 0x2028
-	utf8LineSeparator          = string(utf8LineSeparatorRune)
+	utf8LineSeparator = "\u2028"
 )
 
 func TestFunctionalReaderPrepareRowErrorPaths(t *testing.T) {
@@ -300,6 +299,16 @@ func TestFunctionalReaderPrepareRowErrorPaths(t *testing.T) {
 			},
 			iterErrIs:  []error{csv.ErrParsing, csv.ErrNewlineInUnquotedField},
 			iterErrStr: csv.ErrParsing.Error() + " at byte 2, record 1, field 2: " + csv.ErrNewlineInUnquotedField.Error() + ": line feed",
+		},
+		{
+			when: "expecting only one column but record starts with field separator",
+			then: "error",
+			newOpts: []csv.ReaderOption{
+				csv.ReaderOpts().Reader(strings.NewReader(",")),
+				csv.ReaderOpts().NumFields(1),
+			},
+			iterErrIs:  []error{csv.ErrParsing, csv.ErrTooManyFields},
+			iterErrStr: csv.ErrParsing.Error() + " at byte 1, record 1, field 1: " + csv.ErrTooManyFields.Error() + ": field count exceeds 1",
 		},
 	}
 


### PR DESCRIPTION
Bugfix

Currently the logic for handling states StartOfRecord, StartOfField, and InField is a bit copy-pasted. A block of code was missing from the StartOfRecord handling case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation text to clarify the limitations regarding format and formatting validation.

- **Tests**
  - Expanded test coverage to ensure that CSV input errors, such as unexpected field separators, are accurately identified.

- **Refactor**
  - Optimized CSV processing, including enhancements to header and row management for improved performance and reliability.
  - Introduced a new method for tracking field counts based on record start observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->