### PR TITLE
adding micro optimizations InitialRecordBuffer and InitialRecordBufferSize

### DIFF
--- a/functional_reader_init_error_test.go
+++ b/functional_reader_init_error_test.go
@@ -300,4 +300,31 @@ func TestFunctionalReaderInitializationErrorPaths(t *testing.T) {
 			assert.Nil(t, cr)
 		})
 	})
+
+	t.Run("when creating a CSV reader and specifying a buffer of negative length", func(t *testing.T) {
+		t.Run("should return an error indicating option value is invalid", func(t *testing.T) {
+			cr, err := csv.NewReader(
+				csv.ReaderOpts().Reader(strings.NewReader("")),
+				csv.ReaderOpts().InitialRecordBufferSize(-1),
+			)
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, csv.ErrBadConfig)
+			assert.Equal(t, errors.Join(csv.ErrBadConfig, errors.New(`initial record buffer size must be greater than or equal to zero`)).Error(), err.Error())
+			assert.Nil(t, cr)
+		})
+	})
+
+	t.Run("when creating a CSV reader and specifying both a buffer length and a buffer", func(t *testing.T) {
+		t.Run("should return an error indicating option value is invalid", func(t *testing.T) {
+			cr, err := csv.NewReader(
+				csv.ReaderOpts().Reader(strings.NewReader("")),
+				csv.ReaderOpts().InitialRecordBufferSize(1024*4),
+				csv.ReaderOpts().InitialRecordBuffer(nil),
+			)
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, csv.ErrBadConfig)
+			assert.Equal(t, errors.Join(csv.ErrBadConfig, errors.New(`initial record buffer size cannot be specified when also setting the initial record buffer`)).Error(), err.Error())
+			assert.Nil(t, cr)
+		})
+	})
 }

--- a/functional_reader_test.go
+++ b/functional_reader_test.go
@@ -210,6 +210,25 @@ func (tc *functionalReaderTestCase) Run(t *testing.T) {
 			tc.newOpts = append(v, csv.ReaderOpts().ClearFreedDataMemory(true))
 		}))
 	})
+
+	t.Run("when initRecBuffSize=4096 and "+tc.when, func(t *testing.T) {
+		t.Helper()
+
+		t.Run(name, f(func(tc *functionalReaderTestCase) {
+			v := slices.Clone(tc.newOpts)
+			tc.newOpts = append(v, csv.ReaderOpts().InitialRecordBufferSize(1024*4))
+		}))
+	})
+
+	t.Run("when initRecBuff=[4096]byte and "+tc.when, func(t *testing.T) {
+		t.Helper()
+
+		t.Run(name, f(func(tc *functionalReaderTestCase) {
+			v := slices.Clone(tc.newOpts)
+			buf := make([]byte, 1024*4)
+			tc.newOpts = append(v, csv.ReaderOpts().InitialRecordBuffer(buf))
+		}))
+	})
 }
 
 func TestFunctionalReaderOKPaths(t *testing.T) {

--- a/reader.go
+++ b/reader.go
@@ -422,12 +422,46 @@ func (ReaderOptions) DiscoverRecordSeparator(b bool) ReaderOption {
 	}
 }
 
+// InitialRecordBufferSize is a hint to pre-allocate record buffer space once
+// and reduce the number of re-allocations when processing a reader.
+//
+// Please consider this to be a micro optimization in most circumstances just
+// because it's not likely that most users will know the maximum total record
+// size they wish to target / be under and it's generally a better practice
+// to leave these details to the go runtime to coordinate via standard
+// garbage collection.
+func (ReaderOptions) InitialRecordBufferSize(v int) ReaderOption {
+	return func(cfg *rCfg) {
+		cfg.initialRecordBufferSize = v
+		cfg.initialRecordBufferSizeSet = true
+	}
+}
+
+// InitialRecordBuffer is a hint to pre-allocate record buffer space once
+// externally and pipe it in to reduce the number of re-allocations when
+// processing a reader and reuse it at a later time after the reader is closed.
+//
+// This option should generally not be used. It only exists to assist with
+// processing large numbers of CSV files should memory be a clear constraint.
+// There is no guarantee this buffer will always be used till the end of the
+// csv Reader's lifecycle.
+//
+// Please consider this to be a micro optimization in most circumstances just because is tightens the usage
+// contract of the csv Reader in ways most would not normally consider.
+func (ReaderOptions) InitialRecordBuffer(v []byte) ReaderOption {
+	return func(cfg *rCfg) {
+		cfg.recordBuf = v
+		cfg.recordBufSet = true
+	}
+}
+
 func ReaderOpts() ReaderOptions {
 	return ReaderOptions{}
 }
 
 type rCfg struct {
 	headers   []string
+	recordBuf []byte
 	reader    io.Reader
 	recordSep [2]rune
 	numFields int
@@ -435,6 +469,7 @@ type rCfg struct {
 	// maxNumRecords                      int
 	// maxNumRecordBytes                  int
 	// maxNumBytes                        int
+	initialRecordBufferSize            int
 	fieldSeparator                     rune
 	quote                              rune
 	escape                             rune
@@ -457,6 +492,8 @@ type rCfg struct {
 	errOnNewlineInUnquotedField        bool
 	recordSepSet                       bool
 	clearMemoryAfterFree               bool
+	initialRecordBufferSizeSet         bool
+	recordBufSet                       bool
 }
 
 type Reader struct {
@@ -513,6 +550,14 @@ func (cfg *rCfg) validate() error {
 
 	if cfg.reader == nil {
 		return ErrNilReader
+	}
+
+	if cfg.initialRecordBufferSizeSet && cfg.recordBufSet {
+		return errors.New("initial record buffer size cannot be specified when also setting the initial record buffer")
+	}
+
+	if cfg.initialRecordBufferSizeSet && cfg.initialRecordBufferSize < 0 {
+		return errors.New("initial record buffer size must be greater than or equal to zero")
 	}
 
 	if cfg.quoteSet && cfg.escapeSet && cfg.quote == cfg.escape {
@@ -711,6 +756,7 @@ func NewReader(options ...ReaderOption) (*Reader, error) {
 		removeHeaderRow:                    cfg.removeHeaderRow,
 		errOnNoRows:                        cfg.errOnNoRows,
 		headers:                            headers,
+		recordBuf:                          cfg.recordBuf[:0],
 		recordSep:                          cfg.recordSep,
 		recordSepLen:                       cfg.recordSepLen,
 		removeByteOrderMarker:              cfg.removeByteOrderMarker,
@@ -720,7 +766,7 @@ func NewReader(options ...ReaderOption) (*Reader, error) {
 		errOnNewlineInUnquotedField:        cfg.errOnNewlineInUnquotedField,
 	}
 
-	cr.initPipeline(cfg.reader, cfg.borrowRow, cfg.discoverRecordSeparator, cfg.clearMemoryAfterFree)
+	cr.initPipeline(cfg.reader, cfg.initialRecordBufferSize, cfg.borrowRow, cfg.discoverRecordSeparator, cfg.clearMemoryAfterFree)
 
 	return &cr, nil
 }
@@ -1054,7 +1100,7 @@ func (r *Reader) defaultScan() bool {
 	return r.prepareRow()
 }
 
-func (r *Reader) initPipeline(reader io.Reader, borrowRow, discoverRecordSeparator, clearMemoryAfterFree bool) {
+func (r *Reader) initPipeline(reader io.Reader, initialRecordBufferSize int, borrowRow, discoverRecordSeparator, clearMemoryAfterFree bool) {
 
 	if clearMemoryAfterFree {
 		r.prepareRow = r.prepareRow_memclearEnabled
@@ -1062,6 +1108,10 @@ func (r *Reader) initPipeline(reader io.Reader, borrowRow, discoverRecordSeparat
 	} else {
 		r.prepareRow = r.prepareRow_memclearDisabled
 		r.close = r.defaultClose
+	}
+
+	if initialRecordBufferSize > 0 {
+		r.recordBuf = make([]byte, 0, initialRecordBufferSize)
 	}
 
 	if !(r.removeByteOrderMarker || r.errOnNoByteOrderMarker) {


### PR DESCRIPTION
Adding micro optimizations InitialRecordBuffer and InitialRecordBufferSize.

Also making appendRecBuf implementation more safe given append lacks some guarantees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced CSV reader enhancements enabling users to preallocate buffer space by specifying an initial record buffer size or providing a custom buffer. These options offer improved control over memory usage and performance.
	- Enhanced error reporting now clearly identifies misconfigurations, such as negative buffer sizes or conflicting buffer options, ensuring that configuration issues are caught early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->