### PR TITLE
half step simplification of reader struct

### DIFF
--- a/functional_reader_prepare_row_test.go
+++ b/functional_reader_prepare_row_test.go
@@ -12,7 +12,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 	tcs := []functionalReaderTestCase{
 		{
 			when: "single non-utf8 byte",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(bytes.NewReader([]byte{0xC0})),
@@ -22,7 +21,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "single non-utf8 byte after a full ascii byte",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(bytes.NewReader([]byte{'A', 0xC0})),
@@ -32,7 +30,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "single non-utf8 byte after a comma",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(bytes.NewReader([]byte{',', 0xC0})),
@@ -42,7 +39,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "single non-utf8 byte in quotes with quote set",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(bytes.NewReader([]byte{'"', 0xC0, '"'})),
@@ -55,7 +51,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "single non-utf8 byte in comment with comment set",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(bytes.NewReader(append(append([]byte("# "), 0xC0), []byte("\n1,2")...))),
@@ -68,10 +63,9 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "configured to remove a byte order marker that exists",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
-					csv.ReaderOpts().Reader(bytes.NewReader(append([]byte{0xEF, 0xBB, 0xBF}, []byte("1,2,3")...))),
+					csv.ReaderOpts().Reader(bytes.NewReader(append(bomBytes(), []byte("1,2,3")...))),
 				}
 			},
 			newOpts: []csv.ReaderOption{
@@ -81,7 +75,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "two non record sep characters separated by two record sep and ending in a record sep",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader("a\n\nb\n")),
@@ -91,7 +84,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "two non record sep characters separated by two record sep and not ending in a record sep",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader("a\n\nb")),
@@ -101,7 +93,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "two non record sep characters separated by two record sep and ending in a record sep with TerminalRecordSeparatorEmitsRecord=false",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader("a\n\nb\n")),
@@ -114,7 +105,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "two non record sep characters separated by two record sep and ending in a record sep with TerminalRecordSeparatorEmitsRecord=true",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader("a\n\nb\n")),
@@ -127,7 +117,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "discover record sep enabled and comment line ends file with CR",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader("# neat\r")),
@@ -140,7 +129,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "EOF on first line with comment enabled",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader("#neat")),
@@ -152,7 +140,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "just a comma",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(",")),
@@ -162,7 +149,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes and escapes one column",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"\"1\""`)),
@@ -176,7 +162,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes and escapes two columns with second empty",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"\"1\"",`)),
@@ -190,7 +175,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes and escapes two columns with second empty ending in newline",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"\"1\"",` + "\n")),
@@ -204,7 +188,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes and escapes two columns",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"\"1\"","\"2\""`)),
@@ -218,7 +201,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes and escapes two columns ending in newline",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"\"1\"","\"2\""` + "\n")),
@@ -232,7 +214,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes in field one column",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"1""2"`)),
@@ -245,7 +226,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes in field two columns with second empty",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"1""2",`)),
@@ -258,7 +238,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes in field two columns with second empty ending in newline",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"1""2",` + "\n")),
@@ -271,7 +250,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes in field two columns",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"1""2","3""4"`)),
@@ -284,7 +262,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "quotes in field two columns ending in newline",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader(`"1""2","3""4"` + "\n")),
@@ -297,7 +274,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "comments after start of records and support enabled",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader("#neat1\na,b,c\n#neat2\n1,2,3")),
@@ -450,7 +426,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "BOM removal enabled and EOF is the first event encountered",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader("")),
@@ -462,7 +437,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "BOM removal enabled then normal-rune+EOF",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(strings.NewReader("A")),
@@ -475,7 +449,6 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 		},
 		{
 			when: "BOM removal enabled then normal-rune+EOF",
-			then: "no error",
 			newOptsF: func() []csv.ReaderOption {
 				return []csv.ReaderOption{
 					csv.ReaderOpts().Reader(bytes.NewReader([]byte{0xC0})),
@@ -486,9 +459,64 @@ func TestFunctionalReaderPrepareRowOKPaths(t *testing.T) {
 			},
 			rows: [][]string{{string([]byte{0xC0})}},
 		},
+		{
+			when: "BOM removal and error on no-BOM enabled",
+			newOptsF: func() []csv.ReaderOption {
+				return []csv.ReaderOption{
+					csv.ReaderOpts().Reader(bytes.NewReader(append(bomBytes(), []byte("a,b,c")...))),
+				}
+			},
+			newOpts: []csv.ReaderOption{
+				csv.ReaderOpts().RemoveByteOrderMarker(true),
+				csv.ReaderOpts().ErrorOnNoByteOrderMarker(true),
+			},
+			rows: [][]string{strings.Split("a,b,c", ",")},
+		},
+		{
+			when: "error on no-BOM enabled",
+			newOptsF: func() []csv.ReaderOption {
+				return []csv.ReaderOption{
+					csv.ReaderOpts().Reader(bytes.NewReader(append(bomBytes(), []byte("a,b,c")...))),
+				}
+			},
+			newOpts: []csv.ReaderOption{
+				csv.ReaderOpts().ErrorOnNoByteOrderMarker(true),
+			},
+			rows: [][]string{append([]string{string(bomBytes()) + "a"}, strings.Split("b,c", ",")...)},
+		},
+		{
+			when: "quotes enabled and err on quote in unquoted field enabled but no quotes present",
+			newOptsF: func() []csv.ReaderOption {
+				return []csv.ReaderOption{
+					csv.ReaderOpts().Reader(strings.NewReader("a1,b2,c3")),
+				}
+			},
+			newOpts: []csv.ReaderOption{
+				csv.ReaderOpts().Quote('"'),
+				csv.ReaderOpts().ErrorOnQuotesInUnquotedField(true),
+			},
+			rows: [][]string{strings.Split("a1,b2,c3", ",")},
+		},
+		{
+			when: "escape set and record sep CRNL after closing quote",
+			newOptsF: func() []csv.ReaderOption {
+				return []csv.ReaderOption{
+					csv.ReaderOpts().Reader(strings.NewReader("\"\"\r\n")),
+				}
+			},
+			newOpts: []csv.ReaderOption{
+				csv.ReaderOpts().RecordSeparator("\r\n"),
+				csv.ReaderOpts().Quote('"'),
+				csv.ReaderOpts().Escape('\\'),
+			},
+			rows: [][]string{{""}},
+		},
 	}
 
 	for _, tc := range tcs {
+		if tc.then == "" {
+			tc.then = "no error"
+		}
 		tc.Run(t)
 	}
 }

--- a/functional_writer_error_test.go
+++ b/functional_writer_error_test.go
@@ -138,7 +138,7 @@ func TestFunctionalWriterErrorPaths(t *testing.T) {
 				w := &errWriter{writer: &buf, numWrites: 1, err: io.ErrClosedPipe}
 				tc.newOpts = append(tc.newOpts, csv.WriterOpts().Writer(w))
 				tc.afterTest = func(t *testing.T) {
-					assert.Equal(t, string([]byte{0xEF, 0xBB, 0xBF}), buf.String())
+					assert.Equal(t, string(bomBytes()), buf.String())
 				}
 			},
 			whErrStr: csv.ErrIO.Error() + ": " + io.ErrClosedPipe.Error(),

--- a/functional_writer_test.go
+++ b/functional_writer_test.go
@@ -332,6 +332,10 @@ func (tc *functionalWriterTestCase) Run(t *testing.T) {
 	})
 }
 
+func bomBytes() []byte {
+	return []byte{0xEF, 0xBB, 0xBF}
+}
+
 func TestFunctionalWriterOKPaths(t *testing.T) {
 	tcs := []functionalWriterTestCase{
 		{
@@ -349,7 +353,7 @@ func TestFunctionalWriterOKPaths(t *testing.T) {
 				csv.WriteHeaderOpts().CommentLines("hello world"),
 				csv.WriteHeaderOpts().IncludeByteOrderMarker(true),
 			},
-			res: string([]byte{0xEF, 0xBB, 0xBF}) + "# hello world\n",
+			res: string(bomBytes()) + "# hello world\n",
 		},
 		{
 			when: "rendering a comment header with a 2 col csv header trimmed",

--- a/internal/cmd/generate/prepare_row.go.tmpl
+++ b/internal/cmd/generate/prepare_row.go.tmpl
@@ -1,5 +1,5 @@
 {{define "recBufAppend"}}{{if .ClearMemoryAfterUse}}r.appendRecBuf({{else}}r.recordBuf = append(r.recordBuf, {{end}}{{end}}
-func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{end}}abled() bool {
+func (r *Reader) prepareRow_memclearO{{if .ClearMemoryAfterUse}}n{{else}}ff{{end}}() bool {
 
 	for {
 		c, size, rErr := r.reader.ReadRune()
@@ -18,8 +18,8 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 			// handle a non UTF8 byte
 			//
 
-			if rStateStartOfDoc == r.state {
-				if r.errOnNoByteOrderMarker {
+			if r.state == rStateStartOfDoc {
+				if (r.bitFlags & rFlagErrOnNoBOM) != 0 {
 					r.byteIndex = 0 // special case, no BOM rune was found while at start of doc so no processed bytes were "stable"
 					r.setDone()
 					r.parsingErr(ErrNoByteOrderMarker)
@@ -81,13 +81,13 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 		switch r.state {
 		case rStateStartOfDoc:
 			if !isByteOrderMarker(uint32(c), size) {
-				if r.errOnNoByteOrderMarker {
+				if (r.bitFlags & rFlagErrOnNoBOM) != 0 {
 					r.byteIndex = 0 // special case, no BOM rune was found while at start of doc so no processed bytes were "stable"
 					r.setDone()
 					r.parsingErr(ErrNoByteOrderMarker)
 					return false
 				}
-			} else if r.removeByteOrderMarker {
+			} else if (r.bitFlags & rFlagDropBOM) != 0 {
 				r.state = rStateStartOfRecord
 				continue
 			}
@@ -125,7 +125,7 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 				return false
 			}
 
-			if c == r.quote && r.quoteSet {
+			if c == r.quote && (r.bitFlags & rFlagQuote) != 0 {
 				r.state = rStateInQuotedField
 
 				// not required because quote being set to \r is not allowed when record sep discovery mode is enabled
@@ -138,7 +138,7 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 				continue
 			}
 
-			if c == r.comment && r.commentSet && (!r.afterStartOfRecords || r.commentsAllowedAfterStartOfRecords) {
+			if c == r.comment && (r.bitFlags & rFlagComment) != 0 && ((r.bitFlags & stAfterSOR) == 0 || (r.bitFlags & rFlagCommentAfterSOR) != 0) {
 				r.state = rStateInLineComment
 
 				// not required because quote being set to \r is not allowed when record sep discovery mode is enabled
@@ -153,13 +153,13 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 
 			switch c {
 			case '\r':
-				if r.errOnNewlineInUnquotedField {
+				if (r.bitFlags & rFlagErrOnNLInUF) != 0 {
 					r.setDone()
 					r.parsingErr(errNewlineInUnquotedFieldCarriageReturn)
 					return false
 				}
 			case '\n':
-				if r.errOnNewlineInUnquotedField {
+				if (r.bitFlags & rFlagErrOnNLInUF) != 0 {
 					r.setDone()
 					r.parsingErr(errNewlineInUnquotedFieldLineFeed)
 					return false
@@ -199,7 +199,7 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 				return false
 			}
 
-			if c == r.quote && r.quoteSet {
+			if c == r.quote && (r.bitFlags & rFlagQuote) != 0 {
 				r.state = rStateInQuotedField
 
 				// not required because quote being set to \r is not allowed when record sep discovery mode is enabled
@@ -214,13 +214,13 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 
 			switch c {
 			case '\r':
-				if r.errOnNewlineInUnquotedField {
+				if (r.bitFlags & rFlagErrOnNLInUF) != 0 {
 					r.setDone()
 					r.parsingErr(errNewlineInUnquotedFieldCarriageReturn)
 					return false
 				}
 			case '\n':
-				if r.errOnNewlineInUnquotedField {
+				if (r.bitFlags & rFlagErrOnNLInUF) != 0 {
 					r.setDone()
 					r.parsingErr(errNewlineInUnquotedFieldLineFeed)
 					return false
@@ -258,7 +258,7 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 				return false
 			}
 
-			if c == r.quote && r.quoteSet && r.errOnQuotesInUnquotedField {
+			if c == r.quote && (r.bitFlags & rFlagQuote) != 0 && (r.bitFlags & rFlagErrOnQInUF) != 0 {
 				r.setDone()
 				r.parsingErr(ErrQuoteInUnquotedField)
 				return false
@@ -266,13 +266,13 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 
 			switch c {
 			case '\r':
-				if r.errOnNewlineInUnquotedField {
+				if (r.bitFlags & rFlagErrOnNLInUF) != 0 {
 					r.setDone()
 					r.parsingErr(errNewlineInUnquotedFieldCarriageReturn)
 					return false
 				}
 			case '\n':
-				if r.errOnNewlineInUnquotedField {
+				if (r.bitFlags & rFlagErrOnNLInUF) != 0 {
 					r.setDone()
 					r.parsingErr(errNewlineInUnquotedFieldLineFeed)
 					return false
@@ -286,7 +286,7 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 			case r.quote:
 				r.state = rStateEndOfQuotedField
 			default:
-				if c == r.escape && r.escapeSet {
+				if c == r.escape && (r.bitFlags & rFlagEscape) != 0 {
 					r.state = rStateInQuotedFieldAfterEscape
 					continue
 				}
@@ -315,7 +315,7 @@ func (r *Reader) prepareRow_memclear{{if .ClearMemoryAfterUse}}En{{else}}Dis{{en
 				r.state = rStateStartOfField
 				r.fieldIndex++
 			case r.quote:
-				if r.escapeSet {
+				if (r.bitFlags & rFlagEscape) != 0 {
 					r.setDone()
 					r.parsingErr(ErrUnexpectedQuoteAfterField)
 					return false


### PR DESCRIPTION
Minor bit logic implementation to see minor throughput improvements thanks to cache lines not being crossed and most CPU instruction sets work efficiently with the bit checks.

Real magic would be to flatten out the tight loop into no more than 576 tighter loops without branch statements. There are real tangible gains to be seen there.

The tests added cover half-step flattening that was attempted but ultimately shown to be too slow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes & Improvements**  
  - Enhanced CSV parsing to detect and report formatting issues like field mismatches and unexpected character sequences.

- **New Features**  
  - Introduced additional validation for Byte Order Marker handling and quote configurations, ensuring more reliable CSV processing.

- **Refactor**  
  - Streamlined internal state management for CSV operations, resulting in more efficient and consistent data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->