### PR TITLE
README refresh and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,96 @@
 # csv-go
 
+csv-go
+
 [![Go Report Card](https://goreportcard.com/badge/github.com/josephcopenhaver/csv-go)](https://goreportcard.com/report/github.com/josephcopenhaver/csv-go/v2)
 ![tests](https://github.com/josephcopenhaver/csv-go/actions/workflows/tests.yaml/badge.svg)
 ![code-coverage](https://img.shields.io/badge/code_coverage-100%25-rgb%2852%2C208%2C88%29)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-## Why does this exist?
-I am tired of rewriting this over and over to cover edge cases where other language standard csv implementations have assertions on the format and formatting I cannot guarantee are valid for a given file and how it was constructed. I've written variations that cover far fewer concerns over the years, and I figured I'll make a superset of one that does everything I need and then experiment with making it as efficient as maintainability will allow. Feel free to use however you may wish.
+This package is a highly flexible and performant csv stream reader and writer that opts for strictness and nearly all options off by default. By using the option functions pattern on Reader and Writer creation extreme flexibility can be offered and configuration can be validated up-front. This creates an immutable, clear execution of the strategy.
+
+That being said, the reader is also more performant at the moment than the standard go csv package when compared in an apples-to-apples configuration between the two.
+
+```go
+package main
+
+import (
+	"os"
+
+	"github.com/josephcopenhaver/csv-go/v2"
+)
+
+func main() {
+	r, err := os.Open("input.csv")
+	if err != nil {
+		panic(err)
+	}
+	defer r.Close()
+
+	cr, err := csv.NewReader(
+		csv.ReaderOpts().Reader(r),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer cr.Close()
+
+	w, err := os.Create("output.csv")
+	if err != nil {
+		panic(err)
+	}
+	defer w.Close()
+
+	cw, err := csv.NewWriter(
+		csv.WriterOpts().Writer(w),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer cw.Close()
+
+	for row := range cr.IntoIter() {
+		if _, err := cw.WriteRow(row...); err != nil {
+			panic(err)
+		}
+	}
+	if err := cr.Err(); err != nil {
+		panic(err)
+	}
+}
+```
+
+See the [Reader](./internal/examples/reader/main.go) and [Writer](./internal/examples/writer/main.go) examples for more in-depth usages.
+
+## Reader Features
+
+| Name | option(s) |
+| - | - |
+| Zero allocations | BorrowRow + BorrowFields + InitialRecordBuffer + InitialRecordBufferSize |
+| Format Specification | Comment + CommentsAllowedAfterStartOfRecords + Escape + FieldSeparator + Quote + RecordSeparator + NumFields |
+| Format Discovery | DiscoverRecordSeparator |
+| Data Loss Prevention | ClearFreedDataMemory |
+| Byte Order Marker Support | RemoveByteOrderMarker + ErrorOnNoByteOrderMarker
+| Headers Support | ExpectHeaders + RemoveHeaderRow + TrimHeaders |
+| Reader Buffer tuning | ReaderBuffer + ReaderBufferSize |
+| Format Validation | ErrorOnNoRows + ErrorOnNewlineInUnquotedField + ErrorOnQuotesInUnquotedField |
+| Security Limits | *planned* |
+
+## Writer Features
+
+| Name | option(s) |
+| - | - |
+| Zero allocations | *planned* |
+| Header and Comment Specification | CommentRune + CommentLines + IncludeByteOrderMarker + Headers + TrimHeaders|
+| Format Specification | Escape + FieldSeparator + Quote + RecordSeparator + NumFields |
+| Data Loss Prevention | ClearFreedDataMemory |
+| Encoding Validation | ErrorOnNonUTF8 |
+| Security Limits | *planned* |
+
+---
 
 [CHANGELOG](./docs/version/v2/CHANGELOG.md)
 
 ---
 
-[![Go Documentation](https://godocs.io/github.com/josephcopenhaver/csv-go/v2?status.svg)](https://godocs.io/github.com/josephcopenhaver/csv-go/v2)
+[![Go Reference](https://pkg.go.dev/badge/github.com/josephcopenhaver/csv-go/v2.svg)](https://pkg.go.dev/github.com/josephcopenhaver/csv-go/v2)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ csv-go
 
 This package is a highly flexible and performant single threaded csv stream reader and writer. It opts for strictness with nearly all options off by default. Using the option functions pattern on Reader and Writer creation ensures extreme flexibility can be offered while configuration can be validated up-front in cold paths. This creates an immutable, clear execution of the csv file/stream parsing strategy.
 
-The reader is also more performant at the moment than the standard go csv package when compared in an apples-to-apples configuration between the two. I expect mileage here to vary over time. My primary goals with this lib was to solve my own edge case problems like suspect-encodings/loose-rules and offer something back more aligned with others that think like myself.
+The reader is also [more performant](./docs/BENCHMARKS.md) at the moment than the standard go csv package when compared in an apples-to-apples configuration between the two. I expect mileage here to vary over time. My primary goal with this lib was to solve my own edge case problems like suspect-encodings/loose-rules and offer something back more aligned with others that think like myself.
 
 ```go
 package main

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ csv-go
 ![code-coverage](https://img.shields.io/badge/code_coverage-100%25-rgb%2852%2C208%2C88%29)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-This package is a highly flexible and performant csv stream reader and writer that opts for strictness and nearly all options off by default. By using the option functions pattern on Reader and Writer creation extreme flexibility can be offered and configuration can be validated up-front. This creates an immutable, clear execution of the strategy.
+This package is a highly flexible and performant single threaded csv stream reader and writer. It opts for strictness with nearly all options off by default. Using the option functions pattern on Reader and Writer creation ensures extreme flexibility can be offered while configuration can be validated up-front in cold paths. This creates an immutable, clear execution of the csv file/stream parsing strategy.
 
-That being said, the reader is also more performant at the moment than the standard go csv package when compared in an apples-to-apples configuration between the two.
+The reader is also more performant at the moment than the standard go csv package when compared in an apples-to-apples configuration between the two. I expect mileage here to vary over time. My primary goals with this lib was to solve my own edge case problems like suspect-encodings/loose-rules and offer something back more aligned with others that think like myself.
 
 ```go
 package main
+
+// this is a toy example that reads a csv file and writes to another
 
 import (
 	"os"
@@ -29,6 +31,9 @@ func main() {
 
 	cr, err := csv.NewReader(
 		csv.ReaderOpts().Reader(r),
+		// by default quotes have no meaning
+		// so must be specified to match RFC 4180
+		// csv.ReaderOpts().Quote('"'),
 	)
 	if err != nil {
 		panic(err)

--- a/bench_reader_test.go
+++ b/bench_reader_test.go
@@ -1,0 +1,492 @@
+package csv_test
+
+import (
+	std_csv "encoding/csv"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/josephcopenhaver/csv-go/v2"
+)
+
+const fileContents3c256Rows = `a,b,c
+1,odd,r1
+2,even,r2
+3,odd,r3
+4,even,r4
+5,odd,r5
+6,even,r6
+7,odd,r7
+8,even,r8
+9,odd,r9
+10,even,r10
+11,odd,r11
+12,even,r12
+13,odd,r13
+14,even,r14
+15,odd,r15
+16,even,r16
+17,odd,r17
+18,even,r18
+19,odd,r19
+20,even,r20
+21,odd,r21
+22,even,r22
+23,odd,r23
+24,even,r24
+25,odd,r25
+26,even,r26
+27,odd,r27
+28,even,r28
+29,odd,r29
+30,even,r30
+31,odd,r31
+32,even,r32
+33,odd,r33
+34,even,r34
+35,odd,r35
+36,even,r36
+37,odd,r37
+38,even,r38
+39,odd,r39
+40,even,r40
+41,odd,r41
+42,even,r42
+43,odd,r43
+44,even,r44
+45,odd,r45
+46,even,r46
+47,odd,r47
+48,even,r48
+49,odd,r49
+50,even,r50
+51,odd,r51
+52,even,r52
+53,odd,r53
+54,even,r54
+55,odd,r55
+56,even,r56
+57,odd,r57
+58,even,r58
+59,odd,r59
+60,even,r60
+61,odd,r61
+62,even,r62
+63,odd,r63
+64,even,r64
+65,odd,r65
+66,even,r66
+67,odd,r67
+68,even,r68
+69,odd,r69
+70,even,r70
+71,odd,r71
+72,even,r72
+73,odd,r73
+74,even,r74
+75,odd,r75
+76,even,r76
+77,odd,r77
+78,even,r78
+79,odd,r79
+80,even,r80
+81,odd,r81
+82,even,r82
+83,odd,r83
+84,even,r84
+85,odd,r85
+86,even,r86
+87,odd,r87
+88,even,r88
+89,odd,r89
+90,even,r90
+91,odd,r91
+92,even,r92
+93,odd,r93
+94,even,r94
+95,odd,r95
+96,even,r96
+97,odd,r97
+98,even,r98
+99,odd,r99
+100,even,r100
+101,odd,r101
+102,even,r102
+103,odd,r103
+104,even,r104
+105,odd,r105
+106,even,r106
+107,odd,r107
+108,even,r108
+109,odd,r109
+110,even,r110
+111,odd,r111
+112,even,r112
+113,odd,r113
+114,even,r114
+115,odd,r115
+116,even,r116
+117,odd,r117
+118,even,r118
+119,odd,r119
+120,even,r120
+121,odd,r121
+122,even,r122
+123,odd,r123
+124,even,r124
+125,odd,r125
+126,even,r126
+127,odd,r127
+128,even,r128
+129,odd,r129
+130,even,r130
+131,odd,r131
+132,even,r132
+133,odd,r133
+134,even,r134
+135,odd,r135
+136,even,r136
+137,odd,r137
+138,even,r138
+139,odd,r139
+140,even,r140
+141,odd,r141
+142,even,r142
+143,odd,r143
+144,even,r144
+145,odd,r145
+146,even,r146
+147,odd,r147
+148,even,r148
+149,odd,r149
+150,even,r150
+151,odd,r151
+152,even,r152
+153,odd,r153
+154,even,r154
+155,odd,r155
+156,even,r156
+157,odd,r157
+158,even,r158
+159,odd,r159
+160,even,r160
+161,odd,r161
+162,even,r162
+163,odd,r163
+164,even,r164
+165,odd,r165
+166,even,r166
+167,odd,r167
+168,even,r168
+169,odd,r169
+170,even,r170
+171,odd,r171
+172,even,r172
+173,odd,r173
+174,even,r174
+175,odd,r175
+176,even,r176
+177,odd,r177
+178,even,r178
+179,odd,r179
+180,even,r180
+181,odd,r181
+182,even,r182
+183,odd,r183
+184,even,r184
+185,odd,r185
+186,even,r186
+187,odd,r187
+188,even,r188
+189,odd,r189
+190,even,r190
+191,odd,r191
+192,even,r192
+193,odd,r193
+194,even,r194
+195,odd,r195
+196,even,r196
+197,odd,r197
+198,even,r198
+199,odd,r199
+200,even,r200
+201,odd,r201
+202,even,r202
+203,odd,r203
+204,even,r204
+205,odd,r205
+206,even,r206
+207,odd,r207
+208,even,r208
+209,odd,r209
+210,even,r210
+211,odd,r211
+212,even,r212
+213,odd,r213
+214,even,r214
+215,odd,r215
+216,even,r216
+217,odd,r217
+218,even,r218
+219,odd,r219
+220,even,r220
+221,odd,r221
+222,even,r222
+223,odd,r223
+224,even,r224
+225,odd,r225
+226,even,r226
+227,odd,r227
+228,even,r228
+229,odd,r229
+230,even,r230
+231,odd,r231
+232,even,r232
+233,odd,r233
+234,even,r234
+235,odd,r235
+236,even,r236
+237,odd,r237
+238,even,r238
+239,odd,r239
+240,even,r240
+241,odd,r241
+242,even,r242
+243,odd,r243
+244,even,r244
+245,odd,r245
+246,even,r246
+247,odd,r247
+248,even,r248
+249,odd,r249
+250,even,r250
+251,odd,r251
+252,even,r252
+253,odd,r253
+254,even,r254
+255,odd,r255
+256,even,r256
+`
+
+func BenchmarkRead256Rows(b *testing.B) {
+
+	strReader := strings.NewReader(fileContents3c256Rows)
+	opts := csv.ReaderOpts()
+
+	for b.Loop() {
+		if _, err := strReader.Seek(0, io.SeekStart); err != nil {
+			panic(err)
+		}
+		cr, err := csv.NewReader(
+			opts.Reader(strReader),
+		)
+		if err != nil {
+			panic(err)
+		}
+		defer cr.Close()
+
+		for row := range cr.IntoIter() {
+			_ = row
+		}
+		if err := cr.Err(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkSTDRead256Rows(b *testing.B) {
+
+	strReader := strings.NewReader(fileContents3c256Rows)
+
+	for b.Loop() {
+		if _, err := strReader.Seek(0, io.SeekStart); err != nil {
+			panic(err)
+		}
+		cr := std_csv.NewReader(strReader)
+
+		for {
+			row, err := cr.Read()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				panic(err)
+			}
+			_ = row
+		}
+	}
+}
+
+func BenchmarkRead256RowsBorrowRow(b *testing.B) {
+
+	strReader := strings.NewReader(fileContents3c256Rows)
+	opts := csv.ReaderOpts()
+
+	for b.Loop() {
+		if _, err := strReader.Seek(0, io.SeekStart); err != nil {
+			panic(err)
+		}
+		cr, err := csv.NewReader(
+			opts.Reader(strReader),
+			opts.BorrowRow(true),
+		)
+		if err != nil {
+			panic(err)
+		}
+		defer cr.Close()
+
+		for row := range cr.IntoIter() {
+			_ = row
+		}
+		if err := cr.Err(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkSTDRead256RowsBorrowRow(b *testing.B) {
+
+	strReader := strings.NewReader(fileContents3c256Rows)
+
+	for b.Loop() {
+		if _, err := strReader.Seek(0, io.SeekStart); err != nil {
+			panic(err)
+		}
+		cr := std_csv.NewReader(strReader)
+		cr.ReuseRecord = true
+
+		for {
+			row, err := cr.Read()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				panic(err)
+			}
+			_ = row
+		}
+	}
+}
+
+func BenchmarkRead256RowsBorrowRowBorrowFields(b *testing.B) {
+
+	strReader := strings.NewReader(fileContents3c256Rows)
+	opts := csv.ReaderOpts()
+
+	for b.Loop() {
+		if _, err := strReader.Seek(0, io.SeekStart); err != nil {
+			panic(err)
+		}
+		cr, err := csv.NewReader(
+			opts.Reader(strReader),
+			opts.BorrowRow(true),
+			opts.BorrowFields(true),
+		)
+		if err != nil {
+			panic(err)
+		}
+		defer cr.Close()
+
+		for row := range cr.IntoIter() {
+			_ = row
+		}
+		if err := cr.Err(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkRead256RowsBorrowRowBorrowFieldsRecBuf(b *testing.B) {
+
+	strReader := strings.NewReader(fileContents3c256Rows)
+	opts := csv.ReaderOpts()
+	var recBuf [32]byte
+
+	for b.Loop() {
+		if _, err := strReader.Seek(0, io.SeekStart); err != nil {
+			panic(err)
+		}
+		cr, err := csv.NewReader(
+			opts.Reader(strReader),
+			opts.BorrowRow(true),
+			opts.BorrowFields(true),
+			opts.InitialRecordBuffer(recBuf[:]),
+		)
+		if err != nil {
+			panic(err)
+		}
+		defer cr.Close()
+
+		for row := range cr.IntoIter() {
+			_ = row
+		}
+		if err := cr.Err(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkRead256RowsBorrowRowBorrowFieldsRecBufReadBuf(b *testing.B) {
+
+	strReader := strings.NewReader(fileContents3c256Rows)
+	opts := csv.ReaderOpts()
+	var recBuf [32]byte
+	var readerBuf [32]byte
+
+	for b.Loop() {
+		if _, err := strReader.Seek(0, io.SeekStart); err != nil {
+			panic(err)
+		}
+		cr, err := csv.NewReader(
+			opts.Reader(strReader),
+			opts.BorrowRow(true),
+			opts.BorrowFields(true),
+			opts.InitialRecordBuffer(recBuf[:]),
+			opts.ReaderBuffer(readerBuf[:]),
+		)
+		if err != nil {
+			panic(err)
+		}
+		defer cr.Close()
+
+		for row := range cr.IntoIter() {
+			_ = row
+		}
+		if err := cr.Err(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkRead256RowsBorrowRowBorrowFieldsRecBufReadBufRecSepLF(b *testing.B) {
+
+	strReader := strings.NewReader(fileContents3c256Rows)
+	opts := csv.ReaderOpts()
+	var recBuf [32]byte
+	var readerBuf [32]byte
+
+	for b.Loop() {
+		if _, err := strReader.Seek(0, io.SeekStart); err != nil {
+			panic(err)
+		}
+		cr, err := csv.NewReader(
+			opts.Reader(strReader),
+			opts.BorrowRow(true),
+			opts.BorrowFields(true),
+			opts.InitialRecordBuffer(recBuf[:]),
+			opts.ReaderBuffer(readerBuf[:]),
+			opts.RecordSeparator("\n"),
+		)
+		if err != nil {
+			panic(err)
+		}
+		defer cr.Close()
+
+		for row := range cr.IntoIter() {
+			_ = row
+		}
+		if err := cr.Err(); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,32 @@
+## 📊 Benchmark Results
+
+#### Metric Details
+| Metric | Details |
+|-|-|
+| ns/op | less is better |
+| B/op | (usually) less is better |
+| allocs/op | (usually) less is better |
+| Samples | (usually) more is better |
+
+#### Types of Tests
+
+- Post-Init - focuses on the details of the parsing method after initialization of the resources involved all the way to their deallocation
+
+### ✅ Standard lib's Post-Init Benchmarks
+
+| Link | Benchmark | ns/op | B/op | allocs/op | Samples |
+|---|:---|---:|---:|---:|---:|
+| [SOURCE](../bench_reader_test.go) | BenchmarkSTDReadPostInit256Rows | 29,796 | 16,208 | 522 | 40,191 |
+| [SOURCE](../bench_reader_test.go) | BenchmarkSTDReadPostInit256RowsBorrowRow | 23,657 | 3,920 | 266 | 50,512 |
+
+### 🚀 This lib's Post-Init Benchmarks
+
+| Link | Benchmark | ns/op | B/op | allocs/op | Samples |
+|---|:---|---:|---:|---:|---:|
+| [SOURCE](../bench_reader_test.go) | BenchmarkReadPostInit256Rows | 23,538 | 16,128 | 521 | 50,836 |
+| [SOURCE](../bench_reader_test.go) | BenchmarkReadPostInit256RowsBorrowRow | 18,008 | 3,840 | 265 | 65,846 |
+| [SOURCE](../bench_reader_test.go) | BenchmarkReadPostInit256RowsBorrowRowBorrowFields | 15,014 | 160 | 8 | 79,670 |
+| [SOURCE](../bench_reader_test.go) | BenchmarkReadPostInit256RowsBorrowRowBorrowFieldsReadBuf | 15,142 | 160 | 8 | 80,788 |
+| [SOURCE](../bench_reader_test.go) | BenchmarkReadPostInit256RowsBorrowRowBorrowFieldsRecBuf | 15,010 | 144 | 6 | 79,084 |
+| [SOURCE](../bench_reader_test.go) | BenchmarkReadPostInit256RowsBorrowRowBorrowFieldsReadBufRecBuf | 14,864 | 144 | 6 | 81,040 |
+| [SOURCE](../bench_reader_test.go) | BenchmarkReadPostInit256RowsBorrowRowBorrowFieldsReadBufRecBufNumFields | 14,458 | 0 | 0 | 83,269 |

--- a/functional_reader_init_test.go
+++ b/functional_reader_init_test.go
@@ -124,12 +124,73 @@ func TestFunctionalReaderInitializationPaths(t *testing.T) {
 		})
 	})
 
+	t.Run("when creating a csv reader and row borrowing with no field borrowing implicitly and NumFields set", func(t *testing.T) {
+		t.Run("should not error and un-cloned extracted first row values should remain unchanged", func(t *testing.T) {
+			cr, err := csv.NewReader(
+				csv.ReaderOpts().Reader(strings.NewReader("a,b\n1,2")),
+				csv.ReaderOpts().BorrowRow(true),
+				csv.ReaderOpts().NumFields(2),
+			)
+			assert.Nil(t, err)
+			assert.NotNil(t, cr)
+			assert.Nil(t, cr.Row())
+
+			firstRow := true
+			var f1, f2 string
+			for row := range cr.IntoIter() {
+				if firstRow {
+					firstRow = false
+					f1 = row[0]
+					f2 = row[1]
+				}
+			}
+
+			assert.Nil(t, cr.Err())
+			assert.Nil(t, cr.Close())
+			assert.Nil(t, cr.Row())
+
+			assert.Equal(t, "a", f1)
+			assert.Equal(t, "b", f2)
+		})
+	})
+
 	t.Run("when creating a csv reader and row borrowing with no field borrowing explicitly", func(t *testing.T) {
 		t.Run("should not error and un-cloned extracted first row values should remain unchanged", func(t *testing.T) {
 			cr, err := csv.NewReader(
 				csv.ReaderOpts().Reader(strings.NewReader("a,b\n1,2")),
 				csv.ReaderOpts().BorrowRow(true),
 				csv.ReaderOpts().BorrowFields(false),
+			)
+			assert.Nil(t, err)
+			assert.NotNil(t, cr)
+			assert.Nil(t, cr.Row())
+
+			firstRow := true
+			var f1, f2 string
+			for row := range cr.IntoIter() {
+				if firstRow {
+					firstRow = false
+					f1 = row[0]
+					f2 = row[1]
+				}
+			}
+
+			assert.Nil(t, cr.Err())
+			assert.Nil(t, cr.Close())
+			assert.Nil(t, cr.Row())
+
+			assert.Equal(t, "a", f1)
+			assert.Equal(t, "b", f2)
+		})
+	})
+
+	t.Run("when creating a csv reader and row borrowing with no field borrowing explicitly and NumFields set", func(t *testing.T) {
+		t.Run("should not error and un-cloned extracted first row values should remain unchanged", func(t *testing.T) {
+			cr, err := csv.NewReader(
+				csv.ReaderOpts().Reader(strings.NewReader("a,b\n1,2")),
+				csv.ReaderOpts().BorrowRow(true),
+				csv.ReaderOpts().BorrowFields(false),
+				csv.ReaderOpts().NumFields(2),
 			)
 			assert.Nil(t, err)
 			assert.NotNil(t, cr)
@@ -184,6 +245,37 @@ func TestFunctionalReaderInitializationPaths(t *testing.T) {
 		})
 	})
 
+	t.Run("when creating a csv reader and row borrowing with field borrowing and NumFields set", func(t *testing.T) {
+		t.Run("should not error and un-cloned extracted first row values should change", func(t *testing.T) {
+			cr, err := csv.NewReader(
+				csv.ReaderOpts().Reader(strings.NewReader("a,b\n1,2")),
+				csv.ReaderOpts().BorrowRow(true),
+				csv.ReaderOpts().BorrowFields(true),
+				csv.ReaderOpts().NumFields(2),
+			)
+			assert.Nil(t, err)
+			assert.NotNil(t, cr)
+			assert.Nil(t, cr.Row())
+
+			firstRow := true
+			var f1, f2 string
+			for row := range cr.IntoIter() {
+				if firstRow {
+					firstRow = false
+					f1 = row[0]
+					f2 = row[1]
+				}
+			}
+
+			assert.Nil(t, cr.Err())
+			assert.Nil(t, cr.Close())
+			assert.Nil(t, cr.Row())
+
+			assert.Equal(t, "1", f1)
+			assert.Equal(t, "2", f2)
+		})
+	})
+
 	t.Run("when creating a csv reader and clearing freed data mem and row borrowing with field borrowing", func(t *testing.T) {
 		t.Run("should not error and un-cloned extracted first row values should zero out", func(t *testing.T) {
 			cr, err := csv.NewReader(
@@ -191,6 +283,70 @@ func TestFunctionalReaderInitializationPaths(t *testing.T) {
 				csv.ReaderOpts().BorrowRow(true),
 				csv.ReaderOpts().BorrowFields(true),
 				csv.ReaderOpts().ClearFreedDataMemory(true),
+			)
+			assert.Nil(t, err)
+			assert.NotNil(t, cr)
+			assert.Nil(t, cr.Row())
+
+			firstRow := true
+			var f1, f2 string
+			for row := range cr.IntoIter() {
+				if firstRow {
+					firstRow = false
+					f1 = row[0]
+					f2 = row[1]
+				}
+			}
+
+			assert.Nil(t, cr.Err())
+			assert.Nil(t, cr.Close())
+			assert.Nil(t, cr.Row())
+
+			assert.Equal(t, "\x00", f1)
+			assert.Equal(t, "\x00", f2)
+		})
+	})
+
+	t.Run("when creating a csv reader and clearing freed data mem and row borrowing with field borrowing and NumFields set", func(t *testing.T) {
+		t.Run("should not error and un-cloned extracted first row values should zero out", func(t *testing.T) {
+			cr, err := csv.NewReader(
+				csv.ReaderOpts().Reader(strings.NewReader("a,b\n1,2")),
+				csv.ReaderOpts().BorrowRow(true),
+				csv.ReaderOpts().BorrowFields(true),
+				csv.ReaderOpts().ClearFreedDataMemory(true),
+				csv.ReaderOpts().NumFields(2),
+			)
+			assert.Nil(t, err)
+			assert.NotNil(t, cr)
+			assert.Nil(t, cr.Row())
+
+			firstRow := true
+			var f1, f2 string
+			for row := range cr.IntoIter() {
+				if firstRow {
+					firstRow = false
+					f1 = row[0]
+					f2 = row[1]
+				}
+			}
+
+			assert.Nil(t, cr.Err())
+			assert.Nil(t, cr.Close())
+			assert.Nil(t, cr.Row())
+
+			assert.Equal(t, "\x00", f1)
+			assert.Equal(t, "\x00", f2)
+		})
+	})
+
+	t.Run("when creating a csv reader and clearing freed data mem and row borrowing with field borrowing and NumFields set and record row col 1 is empty", func(t *testing.T) {
+		t.Run("should not error and un-cloned extracted first row values should zero out", func(t *testing.T) {
+			cr, err := csv.NewReader(
+				csv.ReaderOpts().Reader(strings.NewReader("a,b\n,2")),
+				csv.ReaderOpts().BorrowRow(true),
+				csv.ReaderOpts().BorrowFields(true),
+				csv.ReaderOpts().ClearFreedDataMemory(true),
+				csv.ReaderOpts().NumFields(2),
 			)
 			assert.Nil(t, err)
 			assert.NotNil(t, cr)

--- a/internal/examples/reader/example.csv
+++ b/internal/examples/reader/example.csv
@@ -1,4 +1,0 @@
-a,b,c
-test,my"test,"neat ""test"""
-ok,"new
-line",tests

--- a/internal/examples/reader/main.go
+++ b/internal/examples/reader/main.go
@@ -3,22 +3,32 @@ package main
 import (
 	"bytes"
 	_ "embed"
-	"strings"
 
 	"github.com/josephcopenhaver/csv-go/v2"
 )
 
-//go:embed example.csv
+//go:embed pizza.csv
 var data []byte
+
+var expHeaders = []string{
+	"Pizza Type",
+	"Origin Locality",
+	"Is Round",
+}
 
 func main() {
 	r := bytes.NewReader(data)
 
 	op := csv.ReaderOpts()
 	cr, err := csv.NewReader(
-		op.Reader(r),
-		op.Quote('"'),
-		op.ErrorOnQuotesInUnquotedField(false),
+		op.Reader(r),                 // Reader must always be specified
+		op.ExpectHeaders(expHeaders), // ExpectHeaders is an optional validation check
+		op.RemoveHeaderRow(true),     // stops header record from emitting with the data records
+		op.Quote('"'),                // by default quotes have no meaning, so must be specified to match RFC 4180
+		op.ErrorOnNoRows(true),       //
+		// op.NumFields(3),           // not required: will be auto-discovered
+		// op.FieldSeparator(','),    // not required: matches default value
+		// op.RecordSeparator("\n"),  // not required: matches default value
 	)
 	if err != nil {
 		panic(err)
@@ -26,9 +36,19 @@ func main() {
 	defer cr.Close()
 
 	for row := range cr.IntoIter() {
-		println(strings.Join(row, ","))
+		println(row[0], row[1], row[2])
 	}
 	if err := cr.Err(); err != nil {
+		// for a given document stream:
+		// should the number of fields per line ever change,
+		// the reader error unexpectedly, or the contents
+		// of the document violate expectations specified
+		// via config options, then there will be an error
+		// returned here
+
+		// There is no guarantee that the stream has been fully
+		// read when an error is encountered nor should authors
+		// use the errors to infer such a low level of detail.
 		panic(err)
 	}
 }

--- a/internal/examples/reader/pizza.csv
+++ b/internal/examples/reader/pizza.csv
@@ -1,0 +1,14 @@
+Pizza Type,Origin Locality,Is Round
+Neapolitan,"Naples, Italy",TRUE
+New York Style,"New York, USA",TRUE
+Chicago Deep Dish,"Chicago, USA",TRUE
+Sicilian,"Sicily, Italy",FALSE
+Detroit Style,"Detroit, USA",FALSE
+Roman Pizza,"Rome, Italy",FALSE
+St. Louis Style,"St. Louis, USA",TRUE
+Greek Pizza,Greece,TRUE
+California Style,"California, USA",TRUE
+Turkish Pide,Turkey,FALSE
+Fugazza,Argentina,TRUE
+Okonomiyaki,Japan,TRUE
+Khachapuri,Georgia,FALSE

--- a/reader.go
+++ b/reader.go
@@ -210,6 +210,8 @@ func (ReaderOptions) ClearFreedDataMemory(b bool) ReaderOption {
 	}
 }
 
+// ErrorOnNoRows causes cr.Err() to return ErrNoRows should the reader
+// stream terminate before any data records are parsed.
 func (ReaderOptions) ErrorOnNoRows(b bool) ReaderOption {
 	return func(cfg *rCfg) {
 		cfg.errOnNoRows = b
@@ -222,6 +224,8 @@ func (ReaderOptions) TrimHeaders(b bool) ReaderOption {
 		cfg.trimHeaders = b
 	}
 }
+
+// TODO: in V3 alter ExpectHeaders to be vararg rather than a single slice
 
 // ExpectHeaders causes the first row to be recognized as a header row.
 //
@@ -1245,8 +1249,7 @@ func (r *Reader) initPipeline(cfg rCfg) {
 	if cfg.rawBufSizeSet {
 		r.rawBuf = make([]byte, 0, cfg.rawBufSize)
 	} else if !cfg.rawBufSet {
-		var p [defaultReaderBufferSize]byte
-		r.rawBuf = p[:0]
+		r.rawBuf = make([]byte, 0, defaultReaderBufferSize)
 	}
 
 	if cfg.initialRecordBufferSize > 0 {

--- a/reader.go
+++ b/reader.go
@@ -32,7 +32,7 @@ const (
 	// option will allow. It is also the minimum length for any
 	// ReaderBuffer slice argument. This is exported so
 	// configuration which may not be hardcoded by the utilizing
-	// author can mot easily define validation logic and cite
+	// author can more easily define validation logic and cite
 	// the reason for the limit.
 	//
 	// Algorithms used in this lib cannot work with a smaller buffer

--- a/reader.go
+++ b/reader.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultReaderBufferSize = 4096
+	defaultReaderBufferSize = (1 << 12) // 4096
 
 	asciiCarriageReturn = 0x0D
 	asciiLineFeed       = 0x0A
@@ -606,6 +606,7 @@ type Reader struct {
 	recordSep         [2]rune
 	recordBuf         []byte
 	fieldLengths      []int
+	rowBuf            []string
 	headers           []string
 	fieldStart        int
 	numFields         int
@@ -948,6 +949,11 @@ func NewReader(options ...ReaderOption) (*Reader, error) {
 		}
 	}
 
+	var rowBuf []string
+	if cfg.numFields > 0 {
+		rowBuf = make([]string, cfg.numFields)
+	}
+
 	cr := Reader{
 		controlRunes:   string(controlRunes),
 		rawBuf:         cfg.rawBuf[0:0:len(cfg.rawBuf)],
@@ -958,6 +964,7 @@ func NewReader(options ...ReaderOption) (*Reader, error) {
 		comment:        cfg.comment,
 		headers:        headers,
 		recordBuf:      cfg.recordBuf[0:0:len(cfg.recordBuf)],
+		rowBuf:         rowBuf,
 		recordSep:      cfg.recordSep,
 		recordSepLen:   cfg.recordSepLen,
 		bitFlags:       bitFlags,
@@ -1069,12 +1076,36 @@ func (r *Reader) ioErr(err error) {
 	}
 }
 
-func (r *Reader) borrowedRowAndClonedFields() []string {
-	if r.fieldLengths == nil || len(r.fieldLengths) != r.numFields || r.err != nil {
-		return nil
-	}
+func (r *Reader) setRowBorrowedAndFieldsCloned() {
+	if r.rowBuf == nil {
+		r.row = func() []string {
+			if r.fieldLengths == nil || len(r.fieldLengths) != r.numFields || r.err != nil {
+				return nil
+			}
 
-	row := make([]string, len(r.fieldLengths))
+			r.rowBuf = make([]string, len(r.fieldLengths))
+
+			r.row = func() []string {
+				if len(r.fieldLengths) != r.numFields || r.err != nil {
+					return nil
+				}
+
+				strBuf := string(r.recordBuf)
+
+				var p int
+				for i, s := range r.fieldLengths {
+					r.rowBuf[i] = strBuf[p : p+s]
+					p += s
+				}
+
+				return r.rowBuf
+			}
+
+			return r.row()
+		}
+
+		return
+	}
 
 	r.row = func() []string {
 		if len(r.fieldLengths) != r.numFields || r.err != nil {
@@ -1085,22 +1116,57 @@ func (r *Reader) borrowedRowAndClonedFields() []string {
 
 		var p int
 		for i, s := range r.fieldLengths {
-			row[i] = strBuf[p : p+s]
+			r.rowBuf[i] = strBuf[p : p+s]
 			p += s
 		}
 
-		return row
+		return r.rowBuf
 	}
-
-	return r.row()
 }
 
-func (r *Reader) borrowedRowAndBorrowedFields() []string {
-	if r.fieldLengths == nil || len(r.fieldLengths) != r.numFields || r.err != nil {
-		return nil
-	}
+func (r *Reader) setRowBorrowedAndFieldsBorrowed() {
+	if r.rowBuf == nil {
+		r.row = func() []string {
+			if r.fieldLengths == nil || len(r.fieldLengths) != r.numFields || r.err != nil {
+				return nil
+			}
 
-	row := make([]string, len(r.fieldLengths))
+			r.rowBuf = make([]string, len(r.fieldLengths))
+
+			r.row = func() []string {
+				if len(r.fieldLengths) != r.numFields || r.err != nil {
+					return nil
+				}
+
+				var p int
+				for i, s := range r.fieldLengths {
+					if s == 0 {
+						r.rowBuf[i] = ""
+						continue
+					}
+
+					// Usage of unsafe here is what empowers borrowing.
+					//
+					// This is why this option is NOT enabled by default
+					// and never will be. The caller must assure that they
+					// will never write to the backing slice or utilize it
+					// beyond the next call to Row() or Close()
+					//
+					// It will also never be called if the len is zero,
+					// just as an extra precaution.
+					r.rowBuf[i] = unsafe.String(&r.recordBuf[p], s)
+
+					p += s
+				}
+
+				return r.rowBuf
+			}
+
+			return r.row()
+		}
+
+		return
+	}
 
 	r.row = func() []string {
 		if len(r.fieldLengths) != r.numFields || r.err != nil {
@@ -1110,7 +1176,7 @@ func (r *Reader) borrowedRowAndBorrowedFields() []string {
 		var p int
 		for i, s := range r.fieldLengths {
 			if s == 0 {
-				row[i] = ""
+				r.rowBuf[i] = ""
 				continue
 			}
 
@@ -1123,15 +1189,13 @@ func (r *Reader) borrowedRowAndBorrowedFields() []string {
 			//
 			// It will also never be called if the len is zero,
 			// just as an extra precaution.
-			row[i] = unsafe.String(&r.recordBuf[p], s)
+			r.rowBuf[i] = unsafe.String(&r.recordBuf[p], s)
 
 			p += s
 		}
 
-		return row
+		return r.rowBuf
 	}
-
-	return r.row()
 }
 
 func (r *Reader) defaultRow() []string {
@@ -1226,6 +1290,13 @@ func (r *Reader) zeroRecordBuffers() {
 		}
 	}
 
+	if r.rowBuf != nil {
+		v := r.rowBuf[:cap(r.rowBuf)]
+		for i := range v {
+			v[i] = ""
+		}
+	}
+
 	r.resetRecordBuffers()
 }
 
@@ -1262,20 +1333,25 @@ func (r *Reader) initPipeline(cfg rCfg) {
 
 	r.reader = cfg.reader
 
+	if r.numFields == -1 {
+		r.checkNumFields = r.checkNumFieldsWithDiscovery
+	} else {
+		if r.numFields > 0 {
+			r.fieldLengths = make([]int, 0, r.numFields)
+		}
+		if (r.bitFlags & rFlagComment) != 0 {
+			r.checkNumFields = r.checkNumFieldsWithStartOfRecordTracking
+		} else {
+			r.checkNumFields = r.defaultCheckNumFields
+		}
+	}
+
 	if !cfg.borrowRow {
 		r.row = r.defaultRow
 	} else if cfg.borrowFields {
-		r.row = r.borrowedRowAndBorrowedFields
+		r.setRowBorrowedAndFieldsBorrowed()
 	} else {
-		r.row = r.borrowedRowAndClonedFields
-	}
-
-	if r.numFields == -1 {
-		r.checkNumFields = r.checkNumFieldsWithDiscovery
-	} else if (r.bitFlags & rFlagComment) != 0 {
-		r.checkNumFields = r.checkNumFieldsWithStartOfRecordTracking
-	} else {
-		r.checkNumFields = r.defaultCheckNumFields
+		r.setRowBorrowedAndFieldsCloned()
 	}
 
 	// letting any valid utf8 end of line act as the record separator


### PR DESCRIPTION
Benchmarks act as a kind of guide on how to get to zero allocations when parsing CSV.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Expanded and updated the README with detailed usage examples, feature tables, and updated badges.
  - Added a new benchmarks documentation file comparing performance metrics with the standard library.
  - Updated example code to demonstrate new options and clarify error handling.

- **New Features**
  - Added a new reader option to error if no CSV rows are present.
  - Introduced reusable row buffer slice to reduce allocations during reading.

- **Tests**
  - Added comprehensive benchmark tests for various CSV reading configurations.
  - Extended test coverage for CSV reader initialization with option combinations that have new effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->