### PR TITLE
adding FieldWriter Rune benchmark

### DIFF
--- a/bench_writer_test.go
+++ b/bench_writer_test.go
@@ -230,6 +230,18 @@ func BenchmarkFieldWriterAppendTime(b *testing.B) {
 	}
 }
 
+func BenchmarkFieldWriterAppendRune(b *testing.B) {
+	buf := make([]byte, 0, 1)
+	b.ReportAllocs()
+
+	fw := csv.FieldWriters()
+
+	for b.Loop() {
+		f := fw.Rune('T')
+		_, _ = f.AppendText(buf)
+	}
+}
+
 func BenchmarkFieldWriterAppendBoolTrue(b *testing.B) {
 	buf := make([]byte, 0, 1)
 	b.ReportAllocs()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new performance benchmark to measure the efficiency of appending single characters via field writers, aligned with existing benchmark coverage. This enhances performance visibility and helps ensure consistent behavior over time. No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->