### PR TITLE
fix: allocate right sized buffer for negative int types

### DIFF
--- a/docs/version/v3/CHANGELOG.md
+++ b/docs/version/v3/CHANGELOG.md
@@ -1,5 +1,14 @@
 # V3.* Changes[^1]
 
+## v3.1.1 - 2025-10-10
+
+Internal allocation size bugfix. The FieldWriter types that are processed as signed integers
+would for negative values allocate buffers exceeding the size of their values when writing via MarshalText.
+The exceeding size would never be greater than 19 bytes.
+
+This code path is not regularly traversed by csv processing so while no impact is expected - persons
+who chose to use that code path for various tests or quick analysis will see less bytes allocated for their allocation actions.
+
 ## v3.1.0 - 2025-10-08
 
 Changes in v3.0.1 and v3.0.2 are new additions and should have had the minor version bumped.

--- a/ttu_declen_u64_test.go
+++ b/ttu_declen_u64_test.go
@@ -1,6 +1,7 @@
 package csv
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,5 +23,35 @@ func Test_pow10u64(t *testing.T) {
 
 		is.Equal(i, decLenU64(v-1))
 		is.Equal(i+1, decLenU64(v))
+	}
+}
+
+func TestUsageOf_decLenU64(t *testing.T) {
+	t.Parallel()
+
+	is := assert.New(t)
+
+	is.Equal(int(19), decLenU64(math.MaxInt64))
+	is.Equal(int(20), decLenU64(math.MaxUint64))
+
+	// prove the process for negatives
+	{
+		minInt64 := int64(math.MinInt64)
+		overflowedMinInt64AsUint64 := uint64(minInt64)
+
+		// this process is a false positive, do not replicate this block
+		// instead use the next block style!
+		//
+		// is.Equal(overflowedMinInt64AsUint64, uint64(1<<63))
+		// is.Equal(int(19), decLenU64(overflowedMinInt64AsUint64))
+
+		// The above is a false positive, we need to use this process below
+		// for negatives then add one to the result to account for the sign
+
+		is.Equal(int(1), decLenU64(uint64(-int64(-1))))
+		is.Equal(int(9), decLenU64(uint64(-int64(-111111111))))
+		is.Equal(int(19), decLenU64(uint64(-int64(-1111111111111111111))))
+		is.Equal(int(19), decLenU64(uint64(-int64(overflowedMinInt64AsUint64))))
+		is.Equal(int(18), decLenU64(uint64(-int64(-999999999999999999))))
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -164,7 +164,13 @@ func (w *FieldWriter) MarshalText() (text []byte, err error) {
 		//
 		// might be better off making a buffer pool of a fixed size
 		// but I leave that for callers of AppendText to implement
-		base10ByteLen := decLenU64(w._64_bits) + int((w._64_bits&u64signBitMask)>>63)
+		input := w._64_bits
+		var signAdjustment int
+		if input&u64signBitMask != 0 {
+			input = uint64(-int64(w._64_bits))
+			signAdjustment = 1
+		}
+		base10ByteLen := decLenU64(input) + signAdjustment
 
 		b = make([]byte, 0, base10ByteLen)
 	case wfkUint64:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized buffer allocation when converting negative integers to text, reducing overhead in rare scenarios without changing output or API behavior.

* **Documentation**
  * Added v3.1.1 changelog entry (2025-10-10) detailing the allocation optimization and clarifying that there is no user-visible impact.

* **Tests**
  * Expanded test coverage to validate correct length calculations and behavior for large integers and negative values, ensuring robustness across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->