### PR TITLE
runes of known encoding length should use width aware add functions

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1087,8 +1087,8 @@ func internalNewReader(options ...ReaderOption) (Reader, internalReader, error) 
 		controlRuneScape.addByte(asciiLineFeed)
 		controlRuneScape.addByte(asciiVerticalTab)
 		controlRuneScape.addByte(asciiFormFeed)
-		controlRuneScape.addRune(utf8NextLine)
-		controlRuneScape.addRune(utf8LineSeparator)
+		controlRuneScape.addWideRune(utf8NextLine)
+		controlRuneScape.addWideRune(utf8LineSeparator)
 	}
 
 	if cfg.errOnNewlineInUnquotedField {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * A very minor character set management change to reduce operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->